### PR TITLE
[feat] #13 상세페이지로 store id 값 전달

### DIFF
--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import '../styles/Main.css'
+import { useNavigate } from 'react-router-dom';
 
 const Main = () => {
+    const navigate = useNavigate();
     const [activeIndex, setActiveIndex] = useState(0);
     const [listIndex, setListIndex] = useState(0);
     const [storelist, setStoreList] = useState([]);
+    const [storeId, setStoreId] = useState(0);
 
     const messages = [
         { sender: 'me', text: '님아 오늘 뭐먹?' },
@@ -30,6 +33,15 @@ const Main = () => {
         .catch((err) => {
             console.log(err);
         });
+    }
+
+    const moveToDetail = (store) => {
+        const storeId = store.storeId;
+        setStoreId(storeId);
+
+        //localStorage -> localStorage.getItem(storeId) & useLocation -> location.state.storeId로 받아올 수 있음
+        localStorage.setItem('storeId', storeId);
+        navigate('/detail', { state: { storeId } });
     }
 
     useEffect(() => {
@@ -59,7 +71,7 @@ const Main = () => {
                 </div>
                 <div className='storeListWrap'>
                     {storelist.map((store, index) => (
-                        <div key={index} className='storeList'>
+                        <div key={index} className='storeList' onClick={() => {moveToDetail(store)}}>
                             <div  className='storeImg'><img src={store.storePictureUrl} alt="storeImg"/></div>
                             <div className='storeName'>{store.storeName}</div>
                             <div className='storeInfo'>{store.info}</div>

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -22,9 +22,9 @@ const Main = () => {
     };
 
     const getStoreList = (listIndex) => {
-        axios.get(`http://13.60.59.245:8080/api/store/storelist/category/${listIndex}`)
+        axios.get(`http://16.171.231.94:8080/api/store/storelist/category/${listIndex}`)
         .then ((res) => {
-            setStoreList(res.data);
+            setStoreList(res.data.result);
             console.log(res.data);
         })
         .catch((err) => {


### PR DESCRIPTION
## 🔍 무슨 이유로 코드를 변경했나요?
메인페이지에서 가게 상세페이지로 넘어갈 시 해당 가게의 storeId를 넘겨주도록 코드를 추가하였습니다.
<br>

## 💣 어떤 위험이나 장애를 발견했나요?
없습니다.
<br>

## 📷 관련 스크린샷을 첨부해주세요.
클릭된 후 이동하면서 로컬 스토리지에 저장된 값
![image](https://github.com/alwubin/FIND-FE/assets/135022491/4cf2393d-1d76-4f55-801f-4d6a1ab5dcb4)

<br>

## ✅ 완료 사항
- localStorage -> localStorage.getItem(storeId) 
- useLocation -> location.state.storeId
총 두 가지 방식으로 storeId를 받아올 수 있도록 하였습니다.
close #25 
<br>

## 💬 추가 사항
- 현재 마이페이지 자신이 쓴 리뷰에 대한 페이지는 구현 중에 있습니다.